### PR TITLE
Fix/semantic

### DIFF
--- a/backend/app/routers/_utils.py
+++ b/backend/app/routers/_utils.py
@@ -37,6 +37,27 @@ async def get_connection_or_404(
     return conn
 
 
+async def lock_and_reread_connection(conn_id: str, db: AsyncSession) -> Connection:
+    """Re-fetch *conn_id* under ``FOR UPDATE``, bypassing the identity-map cache.
+
+    Call immediately before composing a write to ``Connection.semantic_model``
+    in any handler that read the connection earlier in the same request, so
+    the write merges into the latest committed state rather than a stale
+    snapshot from a concurrent request.
+    """
+    stmt = (
+        select(Connection)
+        .where(Connection.id == conn_id, Connection.is_active.is_(True))
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    result = await db.execute(stmt)
+    conn = result.scalar_one_or_none()
+    if conn is None:
+        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    return conn
+
+
 async def _invalidate_connection_caches(connection_id: str, db: AsyncSession) -> None:
     """Delete QueryCacheEntry, UserSchemaCache, and TableEmbeddingCache rows for
     *connection_id*.

--- a/backend/app/routers/semantic.py
+++ b/backend/app/routers/semantic.py
@@ -40,12 +40,26 @@ from ..services.schema_utils import (
     _schema_from_dict,
     get_or_refresh_schema,
 )
-from ._utils import _invalidate_connection_caches, cached_json_response, get_connection_or_404
+from ._utils import (
+    _invalidate_connection_caches,
+    cached_json_response,
+    get_connection_or_404,
+    lock_and_reread_connection,
+)
 
 _GENERATION_TIMEOUT_SECONDS = 180
 
 router = APIRouter(prefix="/connections", tags=["semantic"])
 logger = logging.getLogger(__name__)
+
+
+def _advance_progress(
+    progress: GenerationProgress | None, tables_done: int
+) -> GenerationProgress | None:
+    """Return *progress* with ``tables_done`` updated, or ``None`` if absent."""
+    if progress is None:
+        return None
+    return progress.model_copy(update={"tables_done": tables_done})
 
 
 # ── Endpoints ──────────────────────────────────────────────────────────────────
@@ -83,7 +97,7 @@ async def update_semantic_model(
     per-column, preserving v2 metadata (``semantic_type``, ``cardinality`` …)
     that the frontend doesn't always echo back.
     """
-    conn = await get_connection_or_404(connection_id, db)
+    conn = await lock_and_reread_connection(connection_id, db)
     existing_dict: dict = dict(conn.semantic_model) if conn.semantic_model else {}
     existing_model = (
         SemanticModel.model_validate(existing_dict) if existing_dict else SemanticModel()
@@ -264,7 +278,7 @@ async def apply_suggestion(
 ) -> SemanticModel:
     """Apply a specific semantic suggestion to the stored model.
 
-    OVERHEAD: app-only — reads/writes PostgreSQL app DB only. No DB re-query.
+    OVERHEAD: app-only — reads/writes PostgreSQL app DB only.
     """
     conn = await get_connection_or_404(connection_id, db)
 
@@ -278,6 +292,9 @@ async def apply_suggestion(
     if suggestion is None:
         raise HTTPException(status_code=404, detail="Suggestion not found")
 
+    # Re-read under a row lock right before merging so this doesn't clobber a
+    # concurrent write (e.g. a batch-generation call) made since the read above.
+    conn = await lock_and_reread_connection(connection_id, db)
     if not conn.semantic_model:
         raise HTTPException(status_code=404, detail="No semantic model to update")
 
@@ -428,6 +445,9 @@ async def generate_semantic_init(
 
 
 @router.post("/{connection_id}/semantic/generate/batch", response_model=SemanticModel)
+# CONCURRENCY=2 in the frontend worker pool roughly doubles request density
+# against this limit; retry/backoff in runBatchWithRetry absorbs occasional
+# 429s. Revisit if logs show frequent 429s on large schemas.
 @limiter.limit("20/minute")
 async def generate_semantic_batch(
     request: Request,
@@ -503,11 +523,35 @@ async def generate_semantic_batch(
         detail = str(exc) if str(exc) else f"Batch {batch_idx} generation failed"
         raise HTTPException(status_code=500, detail=detail) from exc
 
-    merged_tables = {**partial_model.tables, **batch_tables}
-    new_progress = (
-        progress.model_copy(update={"tables_done": batch_idx + 1}) if progress is not None else None
+    # Re-read with a row lock so concurrent batch writes merge into the latest
+    # DB state, not the stale snapshot loaded at request start 40 s ago.
+    # populate_existing=True forces SQLAlchemy to bypass the identity-map cache.
+    locked = await db.execute(
+        select(Connection)
+        .where(Connection.id == connection_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
     )
-    new_partial = partial_model.model_copy(
+    conn_locked = locked.scalar_one()
+    current_model = SemanticModel.model_validate(conn_locked.semantic_model)
+
+    if current_model.generation_status != GenerationStatus.TABLES_PARTIAL:
+        # Another request (e.g. a fresh /generate/init, or /generate/globals
+        # finalizing the model) changed status while this batch call was
+        # awaiting the LLM. Discard this batch's results rather than corrupt
+        # a model that has moved on.
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Semantic generation state changed during batch processing "
+                f"(status is now '{current_model.generation_status}')"
+            ),
+        )
+
+    merged_tables = {**current_model.tables, **batch_tables}
+    new_progress = _advance_progress(current_model.generation_progress, len(merged_tables))
+    new_partial = current_model.model_copy(
         update={"tables": merged_tables, "generation_progress": new_progress}
     )
 
@@ -593,6 +637,23 @@ async def generate_semantic_globals(
         detail = str(exc) if str(exc) else "Globals generation failed"
         raise HTTPException(status_code=500, detail=detail) from exc
 
+    # Re-read under a row lock so this doesn't clobber a concurrent batch
+    # write that landed while the (slow) globals LLM call was in flight.
+    conn_locked = await lock_and_reread_connection(connection_id, db)
+    current_model = SemanticModel.model_validate(conn_locked.semantic_model)
+    if current_model.generation_status not in (
+        GenerationStatus.TABLES_PARTIAL,
+        GenerationStatus.COMPLETE,
+    ):
+        await db.rollback()
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Semantic generation state changed during globals generation "
+                f"(status is now '{current_model.generation_status}')"
+            ),
+        )
+
     # Prune relationship edges to generated tables only
     generated_tables = set(all_tables.keys())
     pruned_relationships = [
@@ -602,7 +663,7 @@ async def generate_semantic_globals(
     ]
 
     dialect = conn.source_type
-    final = partial_model.model_copy(
+    final = current_model.model_copy(
         update={
             "business_metrics": metrics,
             "common_joins": joins,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,11 @@
 fastapi==0.136.1
-starlette==1.0.1
+starlette==1.3.1
 uvicorn[standard]==0.34.0
 sqlalchemy==2.0.36
 asyncpg==0.30.0
 aiomysql==0.3.0
 sqlparse==0.5.4
-cryptography==46.0.7
+cryptography==48.0.1
 httpx==0.28.1
 pydantic==2.10.4
 email-validator==2.2.0
@@ -14,7 +14,7 @@ python-dotenv==1.2.2
 jinja2==3.1.6
 anthropic==0.104.1
 openai==1.109.1
-python-multipart==0.0.27
+python-multipart==0.0.31
 PyJWT==2.13.0
 bcrypt==4.2.1
 slowapi==0.1.9

--- a/backend/tests/test_routers/test_semantic_v2.py
+++ b/backend/tests/test_routers/test_semantic_v2.py
@@ -238,8 +238,9 @@ class TestApplySuggestion:
         )
 
         db = _mock_db(
-            MockResult(single=conn),  # _get_or_404
+            MockResult(single=conn),  # get_connection_or_404
             MockResult(single=sug),  # select suggestion by id
+            MockResult(single=conn),  # lock_and_reread_connection
             MockResult(),  # update Connection
             MockResult(),  # update SemanticSuggestion
             MockResult(),  # delete QueryCacheEntry
@@ -296,8 +297,9 @@ class TestApplySuggestion:
             value={"filter": "status != 'deleted'"},
         )
         db = _mock_db(
-            MockResult(single=conn),  # _get_or_404
+            MockResult(single=conn),  # get_connection_or_404
             MockResult(single=sug),  # select suggestion
+            MockResult(single=conn),  # lock_and_reread_connection
             MockResult(),  # update Connection
             MockResult(),  # update SemanticSuggestion
             MockResult(),  # delete QueryCacheEntry
@@ -320,8 +322,9 @@ class TestApplySuggestion:
             value={"target": "table", "description": "Updated description"},
         )
         db = _mock_db(
-            MockResult(single=conn),  # _get_or_404
+            MockResult(single=conn),  # get_connection_or_404
             MockResult(single=sug),  # select suggestion
+            MockResult(single=conn),  # lock_and_reread_connection
             MockResult(),  # update Connection
             MockResult(),  # update SemanticSuggestion
             MockResult(),  # delete QueryCacheEntry
@@ -340,8 +343,9 @@ class TestApplySuggestion:
         conn = _make_conn(semantic_model=_POPULATED_MODEL)
         sug = _make_suggestion(connection_id="conn-123")
         db = _mock_db(
-            MockResult(single=conn),  # _get_or_404
+            MockResult(single=conn),  # get_connection_or_404
             MockResult(single=sug),  # select suggestion
+            MockResult(single=conn),  # lock_and_reread_connection
             MockResult(),  # update Connection
             MockResult(),  # update SemanticSuggestion
             MockResult(),  # delete QueryCacheEntry
@@ -359,6 +363,7 @@ class TestApplySuggestion:
         db = _mock_db(
             MockResult(single=conn),  # get_connection_or_404
             MockResult(single=sug),  # select suggestion
+            MockResult(single=conn),  # lock_and_reread_connection
             MockResult(),  # update Connection
             MockResult(),  # update SemanticSuggestion
             MockResult(),  # delete QueryCacheEntry
@@ -367,5 +372,6 @@ class TestApplySuggestion:
         )
         app.dependency_overrides[get_db] = lambda: db
         await http_client.post("/api/v1/connections/conn-123/semantic/suggestions/sug-001/apply")
-        # 1 select (get_or_404) + 1 select (suggestion) + 2 updates + 3 deletes = 7
-        assert db.execute.await_count == 7
+        # 1 select (get_or_404) + 1 select (suggestion) + 1 select (lock_and_reread)
+        # + 2 updates + 3 deletes = 8
+        assert db.execute.await_count == 8

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4630,16 +4630,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -4823,9 +4823,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -5071,10 +5071,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7566,9 +7576,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,9 @@
     "zustand": "^5.0.2"
   },
   "overrides": {
-    "ws": ">=8.20.1"
+    "ws": ">=8.21.0",
+    "form-data": ">=4.0.6",
+    "js-yaml": ">=4.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",

--- a/frontend/src/pages/SemanticModelPage.tsx
+++ b/frontend/src/pages/SemanticModelPage.tsx
@@ -10,6 +10,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 import { AlertTriangle, Check, ChevronRight, Pencil, Plus, X } from 'lucide-react';
 
 import { semanticApi } from '../api/semantic';
@@ -397,10 +398,41 @@ export default function SemanticModelPageV2() {
 
       setGenProgress({ tables_done: 0, tables_total: tablesTotal, batch_size: batchSize });
 
-      for (let i = 0; i < batchCount; i++) {
-        await semanticApi.generateBatch(connectionId!, i, providerParam);
-        setGenProgress((p) => (p ? { ...p, tables_done: i + 1 } : null));
-      }
+      const CONCURRENCY = 2;
+      const MAX_RETRIES = 4;
+      const queue = Array.from({ length: batchCount }, (_, i) => i);
+      let cancelled = false;
+
+      const runBatchWithRetry = async (i: number) => {
+        for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+          if (cancelled) throw new Error('cancelled');
+          try {
+            return await semanticApi.generateBatch(connectionId!, i, providerParam);
+          } catch (err: unknown) {
+            const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+            const isNetworkError = axios.isAxiosError(err) && !err.response;
+            const isRetryable = status === 429 || isNetworkError;
+            if (!isRetryable || attempt === MAX_RETRIES - 1) {
+              cancelled = true;
+              throw err;
+            }
+            await new Promise((r) => setTimeout(r, 2000 * 2 ** attempt));
+          }
+        }
+        return undefined;
+      };
+
+      const runWorker = async () => {
+        while (queue.length > 0 && !cancelled) {
+          const i = queue.shift()!;
+          const updated = await runBatchWithRetry(i);
+          const done = updated?.generation_progress?.tables_done;
+          if (done !== undefined) {
+            setGenProgress((p) => (p ? { ...p, tables_done: Math.max(p.tables_done, done) } : null));
+          }
+        }
+      };
+      await Promise.all(Array.from({ length: Math.min(CONCURRENCY, batchCount) }, runWorker));
 
       return semanticApi.generateGlobals(connectionId!, providerParam);
     },

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -333,6 +333,7 @@ function AddProviderInlineForm({
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
             placeholder={displayNameHint}
+            autoComplete="off"
             className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
           />
         </div>
@@ -353,6 +354,7 @@ function AddProviderInlineForm({
               value={model}
               onChange={(e) => setModel(e.target.value)}
               placeholder="e.g. llama3"
+              autoComplete="off"
               className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             />
           )}
@@ -629,6 +631,7 @@ function AddCustomProvider({ onClose }: { onClose: () => void }) {
           <input
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
+            autoComplete="off"
             className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
           />
         </div>
@@ -656,6 +659,7 @@ function AddCustomProvider({ onClose }: { onClose: () => void }) {
             <input
               value={model}
               onChange={(e) => setModel(e.target.value)}
+              autoComplete="off"
               className="mt-1 w-full rounded-md border border-border bg-background px-2 py-1.5 font-mono text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             />
           )}


### PR DESCRIPTION
## Description

Frontend now runs semantic-model batch generation concurrently
(CONCURRENCY=2) instead of sequentially, which exposed several races
in the backend's read-merge-write of Connection.semantic_model and
made the frontend's retry/progress logic unsafe. Re-check
generation_status under the row lock before merging, apply the same
lock-and-reread pattern to update_semantic_model/apply_suggestion/
generate_semantic_globals, stop retrying deterministic 422s, add
cooperative cancellation to the worker pool, and use the server's
authoritative tables_done instead of client-side guessing.

Fixes # (issue number — required for core changes)

## Type of change

- [X] Bug fix
- [ ] New data source adapter
- [ ] New LLM provider adapter
- [ ] Documentation update
- [ ] Other (describe):

## Checklist

- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I agree to the [Contributor License Agreement](../CLA.md)
- [X] My commits follow the conventional commit format
- [X] I have added tests for new functionality
- [X] `ruff check app/ tests/` passes (backend)
- [X] `ruff format --check app/ tests/` passes (backend)
- [X] `eslint` and `tsc --noEmit` pass (frontend)
- [X] New files include the BSL 1.1 license header
